### PR TITLE
Fix ImportError: cannot import name 'antlr_to_tuple' from 'fasm.parser'

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,11 @@ build-packages:
   - curl
   - gnutls-bin
   - openssl
+  - wget
+  - ca-certificates
+  - ca-certificates-java
+  - openjdk-8-jdk-headless
+  - uuid-dev
 
 parts:
   pyjson:
@@ -77,8 +82,11 @@ parts:
       - wheel
       - textx
       - intervaltree
+    stage-packages:
+      - openjdk-8-jre-headless
     plugin: python
     override-build: |
+      make -C ../src/third_party/fasm build
       pip3 install ../src/third_party/fasm/
       snapcraftctl build
     override-prime: |


### PR DESCRIPTION
This fixes Issue #5 

Idk if "make -C ../src/third_party/fasm build" is still needed but last snap i packaged doesn't give any more errors
All this was about java and uuid not being on the snap, so fasm will fallback to slow version